### PR TITLE
SECURITY: Restrict group ip_blocks_list custom field to group admins

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -11,9 +11,11 @@ register_asset "stylesheets/group-settings.scss"
 after_initialize do
   DiscoursePluginRegistry.register_editable_group_custom_field(:ip_blocks_list, self)
   register_group_custom_field_type("ip_blocks_list", :string, max_length: 1000)
-  add_to_serializer(:basic_group, :custom_fields) do
-    { ip_blocks_list: object.custom_fields[:ip_blocks_list] }
-  end
+  add_to_serializer(
+    :basic_group,
+    :custom_fields,
+    include_condition: -> { scope.can_admin_group?(object) },
+  ) { { ip_blocks_list: object.custom_fields[:ip_blocks_list] } }
 
   on(:user_logged_in) do |user|
     return unless SiteSetting.group_membership_ip_block_enabled

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe GroupsController do
+  fab!(:user)
+  fab!(:admin)
+  fab!(:group) { Fabricate(:group, users: [user]) }
+
+  let(:ip_blocks_list) { "198.51.100.0/24" }
+
+  before do
+    enable_current_plugin
+    group.custom_fields["ip_blocks_list"] = ip_blocks_list
+    group.save_custom_fields
+  end
+
+  describe "#show" do
+    it "redacts IP blocks from ordinary group viewers" do
+      sign_in(user)
+
+      get "/groups/#{group.name}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["group"]["custom_fields"]).to be_blank
+      expect(response.body).not_to include(ip_blocks_list)
+
+      sign_in(admin)
+
+      get "/groups/#{group.name}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["group"]["custom_fields"]).to eq(
+        "ip_blocks_list" => ip_blocks_list,
+      )
+    end
+  end
+end


### PR DESCRIPTION
The `ip_blocks_list` group custom field (the IP/CIDR allowlist that auto-grants group membership on login) was added to `BasicGroupSerializer` without any access control.

 That serializer only checks that the requester can *see* the group — not that they can administer it(anyone could see the ip setting range).

Specs were added for both cases(admin & regulars checking group)

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>