### PR TITLE
DEV: Use model extension APIs instead of modifyClass

### DIFF
--- a/admin/assets/javascripts/discourse/initializers/group-custom-field.js
+++ b/admin/assets/javascripts/discourse/initializers/group-custom-field.js
@@ -4,16 +4,10 @@ export default {
   name: "group-custom-field",
   initialize() {
     withPluginApi((api) => {
-      api.modifyClass("model:group", {
-        pluginId: "discourse-group-membership-ip-block",
-
-        custom_fields: {},
-        asJSON() {
-          return Object.assign(this._super(), {
-            custom_fields: this.custom_fields,
-          });
-        },
+      api.addModelField("group", "custom_fields", {
+        defaultValue: () => ({}),
       });
+      api.addModelSaveProperty("group", "custom_fields");
     });
   },
 };


### PR DESCRIPTION
Replaces the `model:group` asJSON override with api.addModelField +
api.addModelSaveProperty for custom_fields.